### PR TITLE
Skip #-quotes in Common Lisp

### DIFF
--- a/lisp-extra-font-lock.el
+++ b/lisp-extra-font-lock.el
@@ -482,8 +482,9 @@ Set match data 1 if character matched is backquote."
                   (and res
                        (or
                         (lisp-extra-font-lock-is-in-comment-or-string)
-                        ;; Don't match ?' and ?`.
-                        (eq (char-before (match-beginning 0)) ??)))))
+                        ;; Don't match ?', ?`, #' or #`.
+                        (eq (char-before (match-beginning 0)) ??)
+                        (eq (char-before (match-beginning 0)) ?\#)))))
     res))
 
 


### PR DESCRIPTION
When using #' with lambdas in CL, the whole lambda form is highlighted as if it was a quoted list. 