### PR TITLE
Optimize fontification by avoiding recalculating a constant regexp

### DIFF
--- a/lisp-extra-font-lock.el
+++ b/lisp-extra-font-lock.el
@@ -577,6 +577,16 @@ the end of the quoted expression."
   "List of `cl-loop' named variable binding parameters.")
 
 
+(defvar lisp-extra-font-lock--loop-keywords-regexp
+  (concat
+   "\\_<"
+   "\\("
+   (regexp-opt (append
+                lisp-extra-font-lock-loop-keywords-with-var
+                lisp-extra-font-lock-loop-keywords))
+   "\\)"
+   "\\_>"))
+
 ;; Match named loop keywords, and (optionally) any bound variables.
 ;;
 ;; Note, does not support "destructuring", i.e. binding several
@@ -589,14 +599,7 @@ the end of the quoted expression."
         (forward-comment (buffer-size))
         (and (< (point) limit)
              (not (looking-at
-                   (concat
-                    "\\_<"
-                    "\\("
-                    (regexp-opt (append
-                                 lisp-extra-font-lock-loop-keywords-with-var
-                                 lisp-extra-font-lock-loop-keywords))
-                    "\\)"
-                    "\\_>")))))
+                   lisp-extra-font-lock--loop-keywords-regexp))))
     (condition-case nil
         (forward-sexp)
       (error (goto-char limit))))


### PR DESCRIPTION
Implements / fixes #8.

regexp-opt can be slow because it also tries to optimize the regexp. For example:

    (regexp-opt (list "aaa" "abb"))
    ;; -> "\\(?:a\\(?:aa\\|bb\\)\\)"

So it shouldn't be run every time a fontification happens.

This does mean that when `lisp-extra-font-lock-loop-keywords-with-var` and `lisp-extra-font-lock-loop-keywords` are changed, the changes would only take effect after the file is reloaded. This shouldn't be a problem though, as these variables are not meant to be changed, and are unlikely to be changed anyways.