### PR TITLE
Apply highlighting to more builtin forms by default

### DIFF
--- a/lisp-extra-font-lock.el
+++ b/lisp-extra-font-lock.el
@@ -228,6 +228,11 @@ special variables like plain variables, set this to
     "let*"
     "letf"
     "letf*"
+    "letrec"
+    "if-let"
+    "if-let*"
+    "when-let"
+    "when-let*"
     "lexical-let"
     "lexical-let*"
     "multiple-value-bind"
@@ -244,6 +249,7 @@ special variables like plain variables, set this to
 (defcustom lisp-extra-font-lock-defun-functions
   '("defun"
     "defun*"
+    "define-inline"
     "defmacro"
     "defmacro*"
     "defsubst"
@@ -256,7 +262,7 @@ special variables like plain variables, set this to
 
 
 (defcustom lisp-extra-font-lock-lambda-functions
-  '("lambda")
+  '("lambda" "pcase-lambda")
   "List of function using same syntax as `lambda' to bind variables."
   :type '(repeat string)
   :group 'lisp-extra-font-lock)
@@ -265,6 +271,7 @@ special variables like plain variables, set this to
 (defcustom lisp-extra-font-lock-dolist-functions
   '("dolist"
     "dotimes"
+    "pcase-dolist"
     "cl-dolist"
     "cl-dotimes")
   "List of function using same syntax as `dolist' to bind variables."
@@ -273,7 +280,9 @@ special variables like plain variables, set this to
 
 
 (defcustom lisp-extra-font-lock-bind-first-functions
-  '("condition-case")
+  '("condition-case"
+    "condition-case-no-debug"
+    "condition-case-unless-debug")
   "List of function that bind their first argument."
   :type '(repeat string)
   :group 'lisp-extra-font-lock)


### PR DESCRIPTION
Existing logic already works well enough. It is enough to just add these forms to the default values.

- let forms like if/when-let and letrec
- builtin define-inline also has the same syntax as defun
- try to highlight pcase-lambda and pcase-dolist like has already been done for pcase-let
- highlight variants of condition-case

While not all features of all forms* here are highlighted, this is already more useful than not applying the highlighting to them.

*: like when-let and if-let's variable omitting